### PR TITLE
Remove dependency on deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 var through = require('through2');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var jsonminify = require('jsonminify');
 
 module.exports = function () {
     'use strict';
-    
+
     return through.obj(function (file, encoding, callback) {
         if (file.isNull()) {
             this.push(file);
@@ -12,14 +12,14 @@ module.exports = function () {
         }
 
         if (file.isStream()) {
-            this.emit('error', new gutil.PluginError('gulp-jsonminify', 'Streaming not supported'));
+            this.emit('error', new PluginError('gulp-jsonminify', 'Streaming not supported'));
             return callback();
         }
 
         try {
             file.contents = new Buffer(jsonminify(file.contents.toString()).toString());
         } catch (err) {
-            this.emit('error', new gutil.PluginError('gulp-jsonminify', err));
+            this.emit('error', new PluginError('gulp-jsonminify', err));
         }
 
         this.push(file);

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "repository": "https://github.com/tcarlsen/gulp-jsonminify.git",
   "dependencies": {
     "jsonminify": "~0.2.3",
-    "through2": "~0.6.5",
-    "gulp-util": "~3.0.4"
+    "plugin-error": "^0.1.2",
+    "through2": "~0.6.5"
   },
   "keywords": [
     "gulpplugin",


### PR DESCRIPTION
As [advised](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5) by the Gulp maintainer, this PR removes the dependency on the now deprecated `gulp-util` in favour of `plugin-error`.